### PR TITLE
Feat: Adding TS and JS Support

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -3,6 +3,7 @@ name: Typescript
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -26,6 +27,6 @@ jobs:
         run: npm run build
       - name: Publish to npm
         run: npm publish --access public
+        working-directory: ./dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-

--- a/.parcelrc
+++ b/.parcelrc
@@ -1,8 +1,0 @@
-{
-  "extends": "@parcel/config-default",
-  "validators": {
-    "*.ts": [
-      "@parcel/validator-typescript",
-    ]
-  }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [v0.1.8] - 2023-03-11
+
+### Changes
+
+- Moving the `webpack` loader plugin into this repository 
+- Modified the `scalefunc` dependency so that while treeshaking if the `fs` dependency is not required it will not be loaded
+- The Go `scalefile` package has also been modified to reuse the `Language` types and definitions from the `scalefunc` package
+
 ## [v0.1.7] - 2023-02-17
 
 ### Changes
@@ -36,7 +44,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release of the Scalefile library.
 
-[unreleased]: https://github.com/loopholelabs/scalefile/compare/v0.1.7...HEAD
+[unreleased]: https://github.com/loopholelabs/scalefile/compare/v0.1.8...HEAD
+[v0.1.8]: https://github.com/loopholelabs/scalefile/compare/v0.1.8
 [v0.1.7]: https://github.com/loopholelabs/scalefile/compare/v0.1.7
 [v0.1.6]: https://github.com/loopholelabs/scalefile/compare/v0.1.6
 [v0.1.5]: https://github.com/loopholelabs/scalefile/compare/v0.1.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loopholelabs/scalefile",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loopholelabs/scalefile",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "apache-2.0",
       "dependencies": {
         "@loopholelabs/polyglot-ts": "^0.4.0",
@@ -61,30 +61,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
-      "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
+      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
+        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
+        "@babel/generator": "^7.21.0",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helpers": "^7.20.7",
-        "@babel/parser": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.0",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.12",
-        "@babel/types": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -109,13 +109,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.14",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
-      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
+      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.7",
+        "@babel/types": "^7.21.0",
         "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -174,13 +175,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -211,9 +212,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.20.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -222,8 +223,8 @@
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.10",
-        "@babel/types": "^7.20.7"
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -281,23 +282,23 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.13",
-        "@babel/types": "^7.20.7"
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -380,9 +381,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
-      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -568,19 +569,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
+        "@babel/generator": "^7.21.1",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.13",
-        "@babel/types": "^7.20.7",
+        "@babel/parser": "^7.21.2",
+        "@babel/types": "^7.21.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -598,9 +599,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -1175,9 +1176,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
-      "integrity": "sha512-5qpnNHUyyEj9H3sm/4Um/bnx1lrQGhe8iqry/1d+cQYCRd/gzYA0YLeq0ezlk4hKx4vO+dsEsNyeowqRqslwQA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1188,9 +1189,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.0.tgz",
-      "integrity": "sha512-ZphTFFd6SFweNAMKD+QJCrWpgkjf4qBuHltiMkKkD6FFrB3NOTRVmetAGTkJ57pa+s6J0yCH06LujWB9rZe94g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
       "cpu": [
         "x64"
       ],
@@ -1201,9 +1202,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.0.tgz",
-      "integrity": "sha512-ztKVV1dO/sSZyGse0PBCq3Pk1PkYjsA/dsEWE7lfrGoAK3i9HpS2o7XjGQ7V4va6nX+xPPOiuYpQwa4Bi6vlww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
       "cpu": [
         "arm"
       ],
@@ -1214,9 +1215,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.0.tgz",
-      "integrity": "sha512-NEX6hdSvP4BmVyegaIbrGxvHzHvTzzsPaxXCsUt0mbLbPpEftsvNwaEVKOowXnLoeuGeD4MaqSwL3BUK2elsUA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
       "cpu": [
         "arm64"
       ],
@@ -1227,9 +1228,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.0.tgz",
-      "integrity": "sha512-9uvdAkZMOPCY7SPRxZLW8XGqBOVNVEhqlgffenN8shA1XR9FWVsSM13nr/oHtNgXg6iVyML7RwWPyqUeThlwxg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
       "cpu": [
         "x64"
       ],
@@ -1240,9 +1241,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.0.tgz",
-      "integrity": "sha512-Wg0+9615kHKlr9iLVcG5I+/CHnf6w3x5UADRv8Ad16yA0Bu5l9eVOROjV7aHPG6uC8ZPFIVVaoSjDChD+Y0pzg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
       "cpu": [
         "x64"
       ],
@@ -2606,9 +2607,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -3094,9 +3095,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001456",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz",
-      "integrity": "sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==",
+      "version": "1.0.30001464",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
+      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==",
       "dev": true,
       "funding": [
         {
@@ -3621,9 +3622,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.302.tgz",
-      "integrity": "sha512-Uk7C+7aPBryUR1Fwvk9VmipBcN9fVsqBO57jV2ZjTm+IZ6BMNqu7EDVEg2HxCNufk6QcWlFsBkhQyQroB2VWKw==",
+      "version": "1.4.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
+      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3937,9 +3938,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -6014,18 +6015,18 @@
       "dev": true
     },
     "node_modules/msgpackr": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.3.tgz",
-      "integrity": "sha512-m2JefwcKNzoHYXkH/5jzHRxAw7XLWsAdvu0FOJ+OLwwozwOV/J6UA62iLkfIMbg7G8+dIuRwgg6oz+QoQ4YkoA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
+      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.0"
+        "msgpackr-extract": "^3.0.1"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.0.tgz",
-      "integrity": "sha512-oy6KCk1+X4Bn5m6Ycq5N1EWl9npqG/cLrE8ga8NX7ZqfqYUUBS08beCQaGq80fjbKBySur0E6x//yZjzNJDt3A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -6036,12 +6037,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.0",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.0"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
     },
     "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
@@ -7220,9 +7221,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.4.tgz",
-      "integrity": "sha512-5yEGuZ3DZradbogeYQ1NaGz7rXVBDWujWlx1PT8efXO6Txn+eWbfKqB2bTDVmFXmePFkoLU6XI8UektMIEA0ug==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+      "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -7480,14 +7481,14 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.25",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.25.tgz",
-      "integrity": "sha512-O1he153qVyoCgJYSvIyY3bPP1wAJTegZfa6tL3APinSZhJOf8CSd8F/21M6ex8pUY/fuY6n0jAsT4fIuMGA6sA==",
+      "version": "0.23.26",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
+      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.2.12",
-        "minimatch": "^6.1.6",
+        "minimatch": "^7.1.3",
         "shiki": "^0.14.1"
       },
       "bin": {
@@ -7510,9 +7511,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7809,9 +7810,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -7875,9 +7876,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
-      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,13 @@
 {
   "name": "@loopholelabs/scalefile",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "The definitions and library for working with Scalefiles",
   "license": "apache-2.0",
   "source": "index.ts",
-  "main": "dist/main.js",
-  "module": "dist/module.js",
-  "types": "dist/types.d.ts",
+  "types": "types.d.ts",
   "scripts": {
-    "build": "parcel build",
+    "build": "rm -rf dist && tsc --outDir dist && cp package.json dist",
     "test": "node --trace-warnings node_modules/.bin/jest --no-cache"
-  },
-  "files": [
-    "dist"
-  ],
-  "targets": {
-    "default": {
-      "distDir": "./dist"
-    }
   },
   "dependencies": {
     "@loopholelabs/polyglot-ts": "^0.4.0",

--- a/scaleFile.ts
+++ b/scaleFile.ts
@@ -18,10 +18,21 @@ import fs from "fs";
 
 import { load, dump } from "js-yaml";
 
-import { VersionErr, LanguageErr, Version, V1Alpha,
-  Language, Go, Rust,
-  AcceptedVersions, AcceptedLanguages
- } from "./scalefunc/scaleFunc";
+import {
+  VersionErr,
+  LanguageErr,
+  Language,
+  Go,
+  AcceptedLanguages
+ } from "./scalefunc";
+
+export type Version = string;
+
+// V1Alpha is the V1 Alpha definition of a ScaleFunc
+export const V1Alpha: Version = "v1alpha";
+
+// AcceptedVersions is an array of acceptable Versions
+export const AcceptedVersions: Version[] = [V1Alpha];
 
 export class Dependency {
   public Name: string;

--- a/scalefile.go
+++ b/scalefile.go
@@ -20,6 +20,7 @@ package scalefile
 
 import (
 	"errors"
+	"github.com/loopholelabs/scalefile/scalefunc"
 	"gopkg.in/yaml.v3"
 	"io"
 	"os"
@@ -38,22 +39,9 @@ const (
 	V1Alpha Version = "v1alpha"
 )
 
-// Language is the Language the Scale Function's Source Language
-type Language string
-
-const (
-	// Go is the Golang Source Language for Scale Functions
-	Go Language = "go"
-	// Rust is the Rust Source Language for Scale Functions
-	Rust Language = "rust"
-)
-
 var (
 	// AcceptedVersions is an array of acceptable Versions
 	AcceptedVersions = []Version{V1Alpha}
-
-	// AcceptedLanguages is an array of acceptable Languages
-	AcceptedLanguages = []Language{Go, Rust}
 )
 
 // Dependency outlines the Dependency of a Scale Function
@@ -64,13 +52,13 @@ type Dependency struct {
 
 // ScaleFile describes the Scale Function and its dependencies
 type ScaleFile struct {
-	Version      Version      `json:"version" yaml:"version"`
-	Name         string       `json:"name" yaml:"name"`
-	Tag          string       `json:"tag" yaml:"tag"`
-	Signature    string       `json:"signature" yaml:"signature"`
-	Language     Language     `json:"language" yaml:"language"`
-	Dependencies []Dependency `json:"dependencies" yaml:"dependencies"`
-	Source       string       `json:"source" yaml:"source"`
+	Version      Version            `json:"version" yaml:"version"`
+	Name         string             `json:"name" yaml:"name"`
+	Tag          string             `json:"tag" yaml:"tag"`
+	Signature    string             `json:"signature" yaml:"signature"`
+	Language     scalefunc.Language `json:"language" yaml:"language"`
+	Dependencies []Dependency       `json:"dependencies" yaml:"dependencies"`
+	Source       string             `json:"source" yaml:"source"`
 }
 
 // Read opens a file at the given path and returns a *ScaleFile
@@ -120,7 +108,7 @@ func Decode(reader io.Reader) (*ScaleFile, error) {
 	}
 
 	invalid = true
-	for _, l := range AcceptedLanguages {
+	for _, l := range scalefunc.AcceptedLanguages {
 		if scalefile.Language == l {
 			invalid = false
 			break
@@ -147,7 +135,7 @@ func Encode(writer io.Writer, scalefile *ScaleFile) error {
 	}
 
 	invalid = true
-	for _, l := range AcceptedLanguages {
+	for _, l := range scalefunc.AcceptedLanguages {
 		if scalefile.Language == l {
 			invalid = false
 			break

--- a/scalefunc/helpers.go
+++ b/scalefunc/helpers.go
@@ -14,4 +14,22 @@
 	limitations under the License.
 */
 
-export * from "./scaleFile";
+package scalefunc
+
+import "os"
+
+// Read opens a file at the given path and returns a *ScaleFile
+func Read(path string) (*ScaleFunc, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	scaleFunc := new(ScaleFunc)
+	return scaleFunc, scaleFunc.Decode(data)
+}
+
+// Write opens a file at the given path and writes the given scalefile to it
+func Write(path string, scaleFunc *ScaleFunc) error {
+	data := scaleFunc.Encode()
+	return os.WriteFile(path, data, 0644)
+}

--- a/scalefunc/helpers.ts
+++ b/scalefunc/helpers.ts
@@ -14,4 +14,15 @@
 	limitations under the License.
 */
 
-export * from "./scaleFile";
+import fs from "fs";
+import {ScaleFunc} from "./scaleFunc";
+
+export function Read(path: string): ScaleFunc {
+    let data = fs.readFileSync(path, null);
+    return ScaleFunc.Decode(data);
+}
+
+export function Write(path: string, scaleFunc: ScaleFunc) {
+    let data = scaleFunc.Encode()
+    fs.writeFileSync(path, data);
+}

--- a/scalefunc/index.ts
+++ b/scalefunc/index.ts
@@ -14,4 +14,4 @@
 	limitations under the License.
 */
 
-export * from "./scaleFile";
+export * from "./scaleFunc";

--- a/scalefunc/scaleFunc.test.ts
+++ b/scalefunc/scaleFunc.test.ts
@@ -23,6 +23,7 @@ import {
   LanguageErr,
   ChecksumErr,
   V1Alpha,
+  ValidString,
 } from "./scaleFunc";
 
 window.TextEncoder = TextEncoder;
@@ -94,29 +95,29 @@ describe("scaleFunc", () => {
 
 describe("ValidName", () => {
   it("Valid Name", () => {
-    expect(ScaleFunc.ValidString("test")).toBe(true);
-    expect(ScaleFunc.ValidString("test1")).toBe(true);
-    expect(ScaleFunc.ValidString("test.1")).toBe(true);
-    expect(ScaleFunc.ValidString("te---.-1")).toBe(true);
-    expect(ScaleFunc.ValidString("test-1")).toBe(true);
+    expect(ValidString("test")).toBe(true);
+    expect(ValidString("test1")).toBe(true);
+    expect(ValidString("test.1")).toBe(true);
+    expect(ValidString("te---.-1")).toBe(true);
+    expect(ValidString("test-1")).toBe(true);
   });
 
   it("Invalid Name", () => {
-    expect(ScaleFunc.ValidString("test_1")).toBe(false);
-    expect(ScaleFunc.ValidString("test 1")).toBe(false);
-    expect(ScaleFunc.ValidString("test1 ")).toBe(false);
-    expect(ScaleFunc.ValidString(" test1")).toBe(false);
-    expect(ScaleFunc.ValidString("test1_")).toBe(false);
-    expect(ScaleFunc.ValidString("test1?")).toBe(false);
-    expect(ScaleFunc.ValidString("test1!")).toBe(false);
-    expect(ScaleFunc.ValidString("test1@")).toBe(false);
-    expect(ScaleFunc.ValidString("test1#")).toBe(false);
-    expect(ScaleFunc.ValidString("test1$")).toBe(false);
-    expect(ScaleFunc.ValidString("test1%")).toBe(false);
-    expect(ScaleFunc.ValidString("test1^")).toBe(false);
-    expect(ScaleFunc.ValidString("test1&")).toBe(false);
-    expect(ScaleFunc.ValidString("test1*")).toBe(false);
-    expect(ScaleFunc.ValidString("test1(")).toBe(false);
-    expect(ScaleFunc.ValidString("test1-1!")).toBe(false);
+    expect(ValidString("test_1")).toBe(false);
+    expect(ValidString("test 1")).toBe(false);
+    expect(ValidString("test1 ")).toBe(false);
+    expect(ValidString(" test1")).toBe(false);
+    expect(ValidString("test1_")).toBe(false);
+    expect(ValidString("test1?")).toBe(false);
+    expect(ValidString("test1!")).toBe(false);
+    expect(ValidString("test1@")).toBe(false);
+    expect(ValidString("test1#")).toBe(false);
+    expect(ValidString("test1$")).toBe(false);
+    expect(ValidString("test1%")).toBe(false);
+    expect(ValidString("test1^")).toBe(false);
+    expect(ValidString("test1&")).toBe(false);
+    expect(ValidString("test1*")).toBe(false);
+    expect(ValidString("test1(")).toBe(false);
+    expect(ValidString("test1-1!")).toBe(false);
   });
 });

--- a/scalefunc/scaleFunc.ts
+++ b/scalefunc/scaleFunc.ts
@@ -24,7 +24,6 @@ import {
   encodeUint8Array,
   decodeUint8Array,
 } from "@loopholelabs/polyglot-ts";
-import fs from "fs";
 
 export const InvalidStringRegex = /[^A-Za-z0-9-.]/;
 
@@ -45,11 +44,17 @@ export const Go: Language = "go";
 // Rust is the Rust Source Language for Scale Functions
 export const Rust: Language = "rust";
 
+// Typescript is the Typescript Source Language for Scale Functions
+export const Typescript: Language = "ts";
+
+// Javascript is the Javascript Source Language for Scale Functions
+export const Javascript: Language = "js";
+
 // AcceptedVersions is an array of acceptable Versions
 export const AcceptedVersions: Version[] = [V1Alpha];
 
 // AcceptedLanguages is an array of acceptable Languages
-export const AcceptedLanguages: Language[] = [Go, Rust];
+export const AcceptedLanguages: Language[] = [Go, Rust, Typescript, Javascript];
 
 export class ScaleFunc {
   public Version: Version;
@@ -142,18 +147,8 @@ export class ScaleFunc {
     sf.Checksum = hash;
     return sf;
   }
+}
 
-  public static ValidString(str: string): boolean {
-    return !InvalidStringRegex.test(str);
-  }
-
-  public static Read(path: string): ScaleFunc {
-    let data = fs.readFileSync(path, null);
-    return ScaleFunc.Decode(data);
-  }
-
-  public static Write(path: string, scaleFunc: ScaleFunc) {
-    let data = scaleFunc.Encode()
-    fs.writeFileSync(path, data);
-  }
+export function ValidString(str: string): boolean {
+  return !InvalidStringRegex.test(str);
 }

--- a/scalefunc/scalefunc.go
+++ b/scalefunc/scalefunc.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"github.com/loopholelabs/polyglot-go"
-	"os"
 	"regexp"
 )
 
@@ -54,6 +53,12 @@ const (
 
 	// Rust is the Rust Source Language for Scale Functions
 	Rust Language = "rust"
+
+	// TypeScript is the TypeScript Source Language for Scale Functions
+	TypeScript Language = "ts"
+
+	// JavaScript is the JavaScript Source Language for Scale Functions
+	JavaScript Language = "js"
 )
 
 var (
@@ -61,7 +66,7 @@ var (
 	AcceptedVersions = []Version{V1Alpha}
 
 	// AcceptedLanguages is an array of acceptable Languages
-	AcceptedLanguages = []Language{Go, Rust}
+	AcceptedLanguages = []Language{Go, Rust, TypeScript, JavaScript}
 )
 
 // ScaleFunc is the type used to define the requirements of a
@@ -79,22 +84,6 @@ type ScaleFunc struct {
 
 func ValidString(str string) bool {
 	return !InvalidStringRegex.MatchString(str)
-}
-
-// Read opens a file at the given path and returns a *ScaleFile
-func Read(path string) (*ScaleFunc, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	scaleFunc := new(ScaleFunc)
-	return scaleFunc, scaleFunc.Decode(data)
-}
-
-// Write opens a file at the given path and writes the given scalefile to it
-func Write(path string, scaleFunc *ScaleFunc) error {
-	data := scaleFunc.Encode()
-	return os.WriteFile(path, data, 0644)
 }
 
 func (s *ScaleFunc) Encode() []byte {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "jest.*"],
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
@@ -8,9 +9,11 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "sourceMap": true,
+    "declaration": true,
     "paths": {
       "scalefile": ["."]
     },
     "types": ["node", "jest"]
-  }
+  },
 }

--- a/webpack/index.ts
+++ b/webpack/index.ts
@@ -1,0 +1,31 @@
+/*
+	Copyright 2022 Loophole Labs
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		   http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+module.exports = function (buffer: Buffer) {
+    let out = "const scale = require('@loopholelabs/scale');";
+    out += "const scaleFunc = require('@loopholelabs/scalefile/scalefunc');";
+    out += "let buffer = new ArrayBuffer(" + buffer.length + ");";
+    out += "let uint8Buffer = new Uint8Array(buffer);";
+    out += "uint8Buffer.set([";
+    for(let i = 0; i < buffer.length; i++) {
+        out += buffer[i] + ","
+    }
+    out += "]);"
+    out += "module.exports = scaleFunc.ScaleFunc.Decode(uint8Buffer);"
+    // @ts-ignore
+    this.callback(null, out);
+}
+module.exports.raw = true


### PR DESCRIPTION
This PR also moves the WebPack loader into this repo and modifies the `scalefunc` dependency so that while treeshaking if the `fs` dependency is not required it will not be loaded. 

The Go `scalefile` package has also been modified to reuse the `Language` types and definitions from the `scalefunc` package